### PR TITLE
Updating Dockerfile, can use single county

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ be able to start loading TIGER data with:
 Where `WA` is the two letter state abbreviation for the state you want to load
 TIGER data from.
 
+Alternatively, to restrict the search area more, you can enter the five digit
+FIPS code for a state and county to load just that county. You can find all county
+FIPS codes [at this Census link](https://www.census.gov/geo/reference/codes/cou.html).
+For Cook County, IL:
+
+`docker-compose run geocoder es_tiger_loader.py 17031`
+
 ### Running the Geocoder
 
 To start the geocoder itself (which can run into issues if it's started at

--- a/geocoder/Dockerfile
+++ b/geocoder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-onbuild
+FROM python:3.5-onbuild
 
 RUN apt-get update -y && apt-get install -y libgeos-dev
 RUN pip install shapely==1.6b2 && pip install pyproj==1.9.5.1


### PR DESCRIPTION
* Changed Dockerfile to `3.5-onbuild` to prevent 3.6 breaking
* If 5 digit FIPS code is specified, just load that county rather than the whole state